### PR TITLE
[Bugfix] Check if $images is an array when pruning

### DIFF
--- a/src/Traits/HasImageField.php
+++ b/src/Traits/HasImageField.php
@@ -65,9 +65,11 @@ trait HasImageField
             }
 
             $images = $content[$index];
-            foreach ($images as $imagePath) {
-                if (!empty($imagePath) && Storage::disk($disk)->exists($imagePath)) {
-                    Storage::disk($disk)->delete($imagePath);
+            if (is_array($images)) {
+                foreach ($images as $imagePath) {
+                    if (!empty($imagePath) && Storage::disk($disk)->exists($imagePath)) {
+                        Storage::disk($disk)->delete($imagePath);
+                    }
                 }
             }
         }


### PR DESCRIPTION
It can cause an item to be not editable or removable when the imageFieldsIndexes has been changed.